### PR TITLE
Minor update: RQT

### DIFF
--- a/atk.yml
+++ b/atk.yml
@@ -78,7 +78,7 @@ services:
         ROS_DISTRO: "humble"
         USER_UID: "@{uid}"
         USER_GID: "@{gid}"
-        APT_DEPENDENCIES: "bash zsh vim git git-lfs python3-pip python3-tk python3-opencv rapidjson-dev ros-humble-usb-cam ros-humble-tf-transformations"
+        APT_DEPENDENCIES: "bash zsh vim git git-lfs python3-pip python3-tk python3-opencv rapidjson-dev ros-humble-usb-cam ros-humble-tf-transformations ros-humble-rqt*"
         PIP_REQUIREMENTS: "wa_simulator pandas matplotlib numpy>=1.19 opencv-python tornado black Pillow torch torchvision pyserial nvidia-pyindex transforms3d"
         USER_GROUPS: "dialout video"
     environment:

--- a/atk.yml
+++ b/atk.yml
@@ -78,7 +78,7 @@ services:
         ROS_DISTRO: "humble"
         USER_UID: "@{uid}"
         USER_GID: "@{gid}"
-        APT_DEPENDENCIES: "bash zsh vim git git-lfs python3-pip python3-tk python3-opencv rapidjson-dev ros-humble-usb-cam ros-humble-tf-transformations ros-humble-rqt*"
+        APT_DEPENDENCIES: "bash zsh vim git git-lfs python3-pip python3-tk python3-opencv rapidjson-dev ros-humble-usb-cam ros-humble-tf-transformations ros-humble-rqt-graph"
         PIP_REQUIREMENTS: "wa_simulator pandas matplotlib numpy>=1.19 opencv-python tornado black Pillow torch torchvision pyserial nvidia-pyindex transforms3d"
         USER_GROUPS: "dialout video"
     environment:


### PR DESCRIPTION
Add rqt dependency to atk.yml file. This allows for easy node/topic visualization in the vnc container so that we don't run into more issues like #17. Run `rqt_graph` in dev container while the A-stack is running to visualize.