### PR TITLE
revert scipy specified version

### DIFF
--- a/workspace/src/localization/ekf_estimation/package.xml
+++ b/workspace/src/localization/ekf_estimation/package.xml
@@ -14,7 +14,7 @@
 
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
-  <exec_depend version_gte="1.8">python3-scipy</exec_depend>
+  <exec_depend>python3-scipy</exec_depend>
   <exec_depend>localization_shared_utils</exec_depend>
 
   <export>

--- a/workspace/src/localization/ground_truth/package.xml
+++ b/workspace/src/localization/ground_truth/package.xml
@@ -14,7 +14,7 @@
 
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
-  <exec_depend version_gte="1.8">python3-scipy</exec_depend>
+  <exec_depend>python3-scipy</exec_depend>
   <exec_depend>localization_shared_utils</exec_depend>
 
   <export>

--- a/workspace/src/localization/localization_shared_utils/package.xml
+++ b/workspace/src/localization/localization_shared_utils/package.xml
@@ -14,7 +14,7 @@
 
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
-  <exec_depend version_gte="1.8">python3-scipy</exec_depend>
+  <exec_depend>python3-scipy</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/workspace/src/localization/particle_filter_estimation/package.xml
+++ b/workspace/src/localization/particle_filter_estimation/package.xml
@@ -14,7 +14,7 @@
 
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
-  <exec_depend version_gte="1.8">python3-scipy</exec_depend>
+  <exec_depend>python3-scipy</exec_depend>
   <exec_depend>localization_shared_utils</exec_depend>
 
   <export>


### PR DESCRIPTION
Doesn't fix the numpy warning in #135 but scipy version specification is no longer necessary.